### PR TITLE
SHEL-102-Cannot-Create-Account-as-Admin

### DIFF
--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -1,13 +1,13 @@
 package entity
 
 // Custom Enum Type
-type roleType string
+type RoleType string
 
 const (
-	Customer   roleType = "customer"
-	Admin      roleType = "admin"
-	Foundation roleType = "foundation"
-	Seller     roleType = "seller"
+	Customer   RoleType = "customer"
+	Admin      RoleType = "admin"
+	Foundation RoleType = "foundation"
+	Seller     RoleType = "seller"
 )
 
 type User struct {
@@ -18,7 +18,7 @@ type User struct {
 	Password       string
 	PhoneNumber    *string  `gorm:"default:null"`
 	ProfileURL     *string  `gorm:"default:null"`
-	Role           roleType `gorm:"type:role_type;default:'customer'"`
+	Role           RoleType `gorm:"type:role_type;default:'customer'"`
 	Address        *string  `gorm:"default:null"`
 	Verified       bool     `gorm:"default:false"`
 	FoundationName *string  `gorm:"default:null"`

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -7,7 +7,6 @@ const (
 	Customer   RoleType = "customer"
 	Admin      RoleType = "admin"
 	Foundation RoleType = "foundation"
-	Seller     RoleType = "seller"
 )
 
 type User struct {

--- a/internal/user/user.service.go
+++ b/internal/user/user.service.go
@@ -32,9 +32,11 @@ func (s *userService) Register(ctx *fiber.Ctx) error {
 	var req dto.RegisterRequest
 	if err := ctx.BodyParser(&req); err != nil {
 		return ctx.Status(fiber.StatusBadRequest).JSON(dto.HttpResponse{
-			Error: err.Error(),
+			Error:   err.Error(),
+			Success: false,
 		})
 	}
+	role := entity.RoleType(req.Role)
 	user := entity.User{
 		Name:           req.Name,
 		Surname:        req.Surname,
@@ -42,7 +44,7 @@ func (s *userService) Register(ctx *fiber.Ctx) error {
 		Password:       req.Password, // pass plain pwd to use case
 		PhoneNumber:    req.PhoneNumber,
 		ProfileURL:     req.ProfileURL,
-		Role:           entity.Customer,
+		Role:           role,
 		Address:        req.Address,
 		Verified:       false,
 		FoundationName: req.FoundationName,


### PR DESCRIPTION
From bug issue SHEL-102, @wit03 raise a problem about admin registration functionality. Due to limited time and ease of integrating API, to register users as different roles, frontend can pass `role` field in body directly to backend.

This pull request includes changes to the `internal/entity/user.go` and `internal/user/user.service.go` files to update the `roleType` type and handle user roles more dynamically. The most important changes include renaming the `roleType` type to `RoleType`, updating the `User` struct to use the new `RoleType`, and modifying the user registration service to handle roles dynamically.

Updates to role type:

* [`internal/entity/user.go`](diffhunk://#diff-28c6510b5d03dfb7ad9c9640512502ed8ca0294901bc303b392ce23cebc6a357L4-R10): **Import** | Renamed `roleType` to `RoleType` and updated the role constants to use `RoleType`.
* [`internal/entity/user.go`](diffhunk://#diff-28c6510b5d03dfb7ad9c9640512502ed8ca0294901bc303b392ce23cebc6a357L21-R21): Updated the `Role` field in the `User` struct to use the new `RoleType`.

Dynamic role handling:

* [`internal/user/user.service.go`](diffhunk://#diff-349d7dc2f14dad3b7c959563ff3a2b8375f54fcebe0d36aabe1c49a5c7863164R36-R47): Modified the `Register` function to dynamically assign the role from the request using the new `RoleType`.